### PR TITLE
Manually upgrade `dot-prop` to resolve Dependabot alert

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,5 +46,8 @@
     "prettier": "^2.1.2",
     "ts-jest": "^26.4.0",
     "typescript": "^4.0.3"
+  },
+  "resolutions": {
+    "dot-prop": "^4.2.1"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1277,7 +1277,7 @@ configstore@^2.0.0:
   resolved "https://registry.yarnpkg.com/configstore/-/configstore-2.1.0.tgz#737a3a7036e9886102aa6099e47bb33ab1aba1a1"
   integrity sha1-c3o6cDbpiGECqmCZ5HuzOrGroaE=
   dependencies:
-    dot-prop "^3.0.0"
+    dot-prop "^4.2.1"
     graceful-fs "^4.1.2"
     mkdirp "^0.5.0"
     object-assign "^4.0.1"
@@ -1488,10 +1488,10 @@ domexception@^2.0.1:
   dependencies:
     webidl-conversions "^5.0.0"
 
-dot-prop@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/dot-prop/-/dot-prop-3.0.0.tgz#1b708af094a49c9a0e7dbcad790aba539dac1177"
-  integrity sha1-G3CK8JSknJoOfbyteQq6U52sEXc=
+dot-prop@^4.2.1:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/dot-prop/-/dot-prop-4.2.1.tgz#45884194a71fc2cda71cbb4bceb3a4dd2f433ba4"
+  integrity sha512-l0p4+mIuJIua0mhxGoh4a+iNL9bmeK5DvnSVQa6T0OhrVmaEa1XScX5Etc673FePCJOArq/4Pa2cLGODUWTPOQ==
   dependencies:
     is-obj "^1.0.0"
 


### PR DESCRIPTION
* `dot-prop` is pulled in as a transitive depdency of
  `math-float64-frexp`, and version 3.0.0 is subject
  to a Dependabot alert
  (https://github.com/advisories/GHSA-ff7x-qrg7-qggm)
* Manually override the version of this package to 4.2.1
  to remove the alert