### PR TITLE
Add `yarn prepack` for publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 # This workflow will do a clean install of node dependencies, lint the source code and run tests
 
-name: Test
+name: Continuous Integration
 
 on: pull_request
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # sketches-js
 
+![Continuous Integration](https://github.com/DataDog/sketches-js/workflows/Continuous%20Integration/badge.svg) [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
+
 This repo contains the TypeScript implementation of the distributed quantile sketch algorithm [DDSketch](http://www.vldb.org/pvldb/vol12/p2195-masson.pdf). DDSketch is mergeable, meaning that multiple sketches from distributed systems can be combined in a central node.
 
 ## Installation

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/sketches-js",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "TypeScript implementation of DDSketch, a distributed quantile sketch algorithm ",
   "license": "Apache-2.0",
   "repository": "https://github.com/DataDog/sketches-js",
@@ -27,6 +27,7 @@
     "clean": "rm -rf dist/*",
     "test": "jest",
     "lint": "eslint \"src/**/*.{js,ts}\"",
+    "prepack": "yarn build",
     "typecheck": "tsc --noEmit",
     "generate:proto": "pbjs -t static-module -w commonjs -o src/ddsketch/proto/compiled.js src/ddsketch/proto/DDSketch.proto && pbts -o src/ddsketch/proto/compiled.d.ts src/ddsketch/proto/compiled.js"
   },


### PR DESCRIPTION
* In the `publish.yml` workflow, we need `yarn prepack` to run before
  `yarn pack` so that the built "dist/" directory is available for
  publishing
* This should fix the package being published on NPM without any of its
  .js files: https://unpkg.com/browse/@datadog/sketches-js@0.5.0/
* Add badges to README