### PR TITLE
lazy load protobuf so that it is not loaded when not needed

### DIFF
--- a/src/ddsketch/DDSketch.ts
+++ b/src/ddsketch/DDSketch.ts
@@ -7,7 +7,6 @@
 
 import { DenseStore } from './store';
 import { Mapping, KeyMapping, LogarithmicMapping } from './mapping';
-import { DDSketch as ProtoDDSketch } from './proto/compiled';
 
 const DEFAULT_RELATIVE_ACCURACY = 0.01;
 
@@ -185,6 +184,7 @@ class BaseDDSketch {
 
     /** Serialize a DDSketch to protobuf format */
     toProto(): Uint8Array {
+        const { DDSketch: ProtoDDSketch } = require('./proto/compiled');
         const message = ProtoDDSketch.create({
             mapping: this.mapping.toProto(),
             positiveValues: this.store.toProto(),
@@ -203,6 +203,8 @@ class BaseDDSketch {
      * @param buffer Byte array containing DDSketch in protobuf format (from DDSketch.toProto)
      */
     static fromProto(buffer: Uint8Array): DDSketch {
+        const { DDSketch: ProtoDDSketch } = require('./proto/compiled');
+
         const decoded = ProtoDDSketch.decode(buffer);
         const mapping = KeyMapping.fromProto(decoded.mapping);
         const store = DenseStore.fromProto(decoded.positiveValues);

--- a/src/ddsketch/mapping/CubicallyInterpolatedMapping.ts
+++ b/src/ddsketch/mapping/CubicallyInterpolatedMapping.ts
@@ -8,7 +8,7 @@
 import { KeyMapping } from './KeyMapping';
 import frexp from '@stdlib/math-base-special-frexp';
 import ldexp from '@stdlib/math-base-special-ldexp';
-import { IndexMapping as IndexMappingProto } from '../proto/compiled';
+import type { IndexMapping as IndexMappingProtoType } from '../proto/compiled';
 
 /**
  * A fast KeyMapping that approximates the memory-optimal LogarithmicMapping by
@@ -67,7 +67,8 @@ export class CubicallyInterpolatedMapping extends KeyMapping {
         return this._cubicExp2Approx(value / this._multiplier);
     }
 
-    _protoInterpolation(): IndexMappingProto.Interpolation {
+    _protoInterpolation(): IndexMappingProtoType.Interpolation {
+        const { IndexMapping: IndexMappingProto } = require('../proto/compiled');
         return IndexMappingProto.Interpolation.CUBIC;
     }
 }

--- a/src/ddsketch/mapping/KeyMapping.ts
+++ b/src/ddsketch/mapping/KeyMapping.ts
@@ -10,9 +10,9 @@ import {
     LogarithmicMapping,
     CubicallyInterpolatedMapping
 } from './index';
-import {
+import type {
     IIndexMapping,
-    IndexMapping as ProtoIndexMapping
+    IndexMapping as ProtoIndexMappingType
 } from '../proto/compiled';
 import type { Mapping } from './types';
 
@@ -78,6 +78,7 @@ export class KeyMapping implements Mapping {
     }
 
     toProto(): IIndexMapping {
+        const { IndexMapping: ProtoIndexMapping } = require('../proto/compiled');
         return ProtoIndexMapping.create({
             gamma: this.gamma,
             indexOffset: this._offset,
@@ -86,6 +87,8 @@ export class KeyMapping implements Mapping {
     }
 
     static fromProto(protoMapping?: IIndexMapping | null): KeyMapping {
+        const { IndexMapping: ProtoIndexMapping } = require('../proto/compiled');
+
         if (
             !protoMapping ||
             /* Double equals (==) is intentional here to check for
@@ -126,7 +129,8 @@ export class KeyMapping implements Mapping {
         return Math.pow(2, value / this._multiplier);
     }
 
-    _protoInterpolation(): ProtoIndexMapping.Interpolation {
+    _protoInterpolation(): ProtoIndexMappingType.Interpolation {
+        const { IndexMapping: ProtoIndexMapping } = require('../proto/compiled');
         return ProtoIndexMapping.Interpolation.NONE;
     }
 }

--- a/src/ddsketch/mapping/LinearlyInterpolatedMapping.ts
+++ b/src/ddsketch/mapping/LinearlyInterpolatedMapping.ts
@@ -8,7 +8,7 @@
 import { KeyMapping } from './KeyMapping';
 import frexp from '@stdlib/math-base-special-frexp';
 import ldexp from '@stdlib/math-base-special-ldexp';
-import { IndexMapping as IndexMappingProto } from '../proto/compiled';
+import { IndexMapping as IndexMappingProtoType } from '../proto/compiled';
 
 /**
  * A fast KeyMapping that approximates the memory-optimal one
@@ -50,7 +50,8 @@ export class LinearlyInterpolatedMapping extends KeyMapping {
         return Math.pow(2, value / this._multiplier);
     }
 
-    _protoInterpolation(): IndexMappingProto.Interpolation {
+    _protoInterpolation(): IndexMappingProtoType.Interpolation {
+        const { IndexMapping: IndexMappingProto } = require('../proto/compiled');
         return IndexMappingProto.Interpolation.LINEAR;
     }
 }

--- a/src/ddsketch/mapping/LogarithmicMapping.ts
+++ b/src/ddsketch/mapping/LogarithmicMapping.ts
@@ -6,7 +6,7 @@
  */
 
 import { KeyMapping } from './KeyMapping';
-import { IndexMapping as IndexMappingProto } from '../proto/compiled';
+import { IndexMapping as IndexMappingProtoType } from '../proto/compiled';
 
 /**
  * A memory-optimal KeyMapping, i.e., given a targeted relative accuracy, it
@@ -27,7 +27,8 @@ export class LogarithmicMapping extends KeyMapping {
         return Math.pow(2, value / this._multiplier);
     }
 
-    _protoInterpolation(): IndexMappingProto.Interpolation {
+    _protoInterpolation(): IndexMappingProtoType.Interpolation {
+        const { IndexMapping: IndexMappingProto } = require('../proto/compiled');
         return IndexMappingProto.Interpolation.NONE;
     }
 }

--- a/src/ddsketch/store/DenseStore.ts
+++ b/src/ddsketch/store/DenseStore.ts
@@ -7,7 +7,7 @@
 
 import { sumOfRange } from './util';
 import type { Store } from './types';
-import { Store as ProtoStore, IStore } from '../proto/compiled';
+import type { IStore } from '../proto/compiled';
 
 /** The default number of bins to grow when necessary */
 const CHUNK_SIZE = 128;
@@ -232,6 +232,7 @@ export class DenseStore implements Store<DenseStore> {
     }
 
     toProto(): IStore {
+        const { Store: ProtoStore } = require('../proto/compiled');
         return ProtoStore.create({
             contiguousBinCounts: this.bins,
             contiguousBinIndexOffset: this.offset


### PR DESCRIPTION
### What does this PR do?

Lazy load protobuf so that it is not loaded when not needed.

### Motivation

After the changes introduced in #16, protobuf is now by far the biggest contributor to the load time of the library. Lazy loading it only when needed reduces the loading time by ~5x. This has the downside however to potentially be loading protobuf during a request at runtime, which could introduce latency for the first request while the library is loading. The proper way to handle this would be to split `sketches-js` in multiple packages, so that it is known at install time whether protobuf will be used. This however means a much bigger change, but if it's a possibility then it should be favoured over this PR.