### PR TITLE
set zeroCount stat when merging sketches

### DIFF
--- a/src/ddsketch/DDSketch.ts
+++ b/src/ddsketch/DDSketch.ts
@@ -148,6 +148,7 @@ class BaseDDSketch {
         this.store.merge(sketch.store);
 
         /* Merge summary stats */
+        this.zeroCount += sketch.zeroCount;
         this.count += sketch.count;
         this.sum += sketch.sum;
         if (sketch.min < this.min) {


### PR DESCRIPTION
when merging two sketches together, the merged sketch `zeroCount` is not added to the caller, leading to inconsistent results when getting values at quantiles   