### PR TITLE
mark protobufjs as a dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,9 @@
     "typecheck": "tsc --noEmit",
     "generate:proto": "pbjs -t static-module -w commonjs -o src/ddsketch/proto/compiled.js src/ddsketch/proto/DDSketch.proto && pbts -o src/ddsketch/proto/compiled.d.ts src/ddsketch/proto/compiled.js"
   },
-  "dependencies": {},
+  "dependencies": {
+    "protobufjs": "^7.2.6"
+  },
   "devDependencies": {
     "@types/jest": "^26.0.14",
     "@typescript-eslint/eslint-plugin": "^4.2.0",
@@ -41,7 +43,6 @@
     "eslint-plugin-prettier": "^3.1.4",
     "jest": "^26.4.2",
     "prettier": "^2.1.2",
-    "protobufjs": "^7.2.6",
     "ts-jest": "^26.4.0",
     "typescript": "^4.0.3"
   }


### PR DESCRIPTION
Fixes https://github.com/DataDog/sketches-js/issues/26

Fixes this error when importing datadog without the dependency:

```
Error: Cannot find module 'protobufjs/minimal'
Require stack:
- /usr/src/app/node_modules/@datadog/sketches-js/dist/ddsketch/proto/compiled.js
- /usr/src/app/node_modules/@datadog/sketches-js/dist/ddsketch/DDSketch.js
- /usr/src/app/node_modules/@datadog/sketches-js/dist/ddsketch/index.js
- /usr/src/app/node_modules/@datadog/sketches-js/dist/index.js
- /usr/src/app/node_modules/dd-trace/packages/dd-trace/src/histogram.js
- /usr/src/app/node_modules/dd-trace/packages/dd-trace/src/dogstatsd.js
- /usr/src/app/node_modules/dd-trace/packages/dd-trace/src/proxy.js
- /usr/src/app/node_modules/dd-trace/packages/dd-trace/src/index.js
- /usr/src/app/node_modules/dd-trace/packages/dd-trace/index.js
- /usr/src/app/node_modules/dd-trace/index.js
- /usr/src/app/dist/src/shared/datadog/tracer.js
- /usr/src/app/dist/src/main.js
    at Function.Module._resolveFilename (node:internal/modules/cjs/loader:1144:15)
    at Function.Module._load (node:internal/modules/cjs/loader:985:27)
    at Module.require (node:internal/modules/cjs/loader:1235:19)
    at Module.Hook.Module.require (/usr/src/app/node_modules/dd-trace/packages/dd-trace/src/ritm.js:64:27)
    at require (node:internal/modules/helpers:176:18)
    at Object.<anonymous> (/usr/src/app/node_modules/@datadog/sketches-js/dist/ddsketch/proto/compiled.js:3:17)
    at Module._compile (node:internal/modules/cjs/loader:1376:14)
    at Object.Module._extensions..js (node:internal/modules/cjs/loader:1435:10)
    at Module.load (node:internal/modules/cjs/loader:1207:32)
    at Function.Module._load (node:internal/modules/cjs/loader:1023:12)
Waiting for the debugger to disconnect...
```