### PR TITLE
Adds a toJSON and fromJSON route for serialization

### DIFF
--- a/src/ddsketch/DDSketch.ts
+++ b/src/ddsketch/DDSketch.ts
@@ -218,6 +218,111 @@ class BaseDDSketch {
 
         return new BaseDDSketch({ mapping, store, negativeStore, zeroCount });
     }
+
+    /**
+     * Serialize a DDSketch to JSON format as a compact tuple array
+     *
+     * Format: [gamma, indexOffset, positiveValues, negativeValues, zeroCount]
+     * - gamma: number - mapping gamma value
+     * - indexOffset: number - mapping index offset
+     * - positiveValues: [offset, [idx, count], ...] - sparse positive store
+     * - negativeValues: [offset, [idx, count], ...] - sparse negative store
+     * - zeroCount: number - count of zero values
+     *
+     * Stores use sparse representation where only non-zero bins are included
+     * as [index, count] pairs, with indices relative to the offset.
+     *
+     * Marked as unknown to signal it is meant to be considered opaque
+     */
+    toJSON(): unknown[] {
+        // Helper to create sparse representation: [offset, [idx, count], ...]
+        const sparseStore = (store: DenseStore): unknown[] => {
+            const result: unknown[] = [store.offset];
+            for (let i = 0; i < store.bins.length; i++) {
+                if (store.bins[i] > 0) {
+                    result.push([i, store.bins[i]]);
+                }
+            }
+            return result;
+        };
+
+        return [
+            this.mapping.gamma,
+            (this.mapping as KeyMapping)._offset,
+            sparseStore(this.store),
+            sparseStore(this.negativeStore),
+            this.zeroCount
+        ];
+    }
+
+    /**
+     * Deserialize a DDSketch from JSON tuple array
+     *
+     * Note: `fromJSON` currently loses summary statistics for the original
+     * sketch (i.e. `min`, `max`, `sum`, `count`)
+     *
+     * @param json Tuple array containing DDSketch data (from DDSketch.toJSON)
+     */
+    static fromJSON(json: unknown): DDSketch {
+        if (!Array.isArray(json) || json.length !== 5) {
+            throw new Error(
+                'Invalid JSON: expected array of length 5 [gamma, indexOffset, positiveValues, negativeValues, zeroCount]'
+            );
+        }
+
+        const [gamma, indexOffset, positiveValues, negativeValues, zeroCount] =
+            json;
+
+        if (typeof gamma !== 'number') {
+            throw new Error('Invalid JSON: gamma must be a number');
+        }
+
+        if (typeof indexOffset !== 'number') {
+            throw new Error('Invalid JSON: indexOffset must be a number');
+        }
+
+        if (!Array.isArray(positiveValues) || positiveValues.length === 0) {
+            throw new Error(
+                'Invalid JSON: positiveValues must be a non-empty array'
+            );
+        }
+
+        if (!Array.isArray(negativeValues) || negativeValues.length === 0) {
+            throw new Error(
+                'Invalid JSON: negativeValues must be a non-empty array'
+            );
+        }
+
+        if (typeof zeroCount !== 'number') {
+            throw new Error('Invalid JSON: zeroCount must be a number');
+        }
+
+        // Reconstruct the mapping
+        const mapping = LogarithmicMapping.fromGammaOffset(gamma, indexOffset);
+
+        // Helper to reconstruct store from sparse representation
+        const reconstructStore = (data: unknown[]): DenseStore => {
+            const store = new DenseStore();
+            const offset = data[0] as number;
+            store.offset = offset;
+
+            for (let i = 1; i < data.length; i++) {
+                const pair = data[i] as number[];
+                const [relativeIndex, count] = pair;
+                if (count > 0) {
+                    store.add(offset + relativeIndex, count);
+                }
+            }
+
+            return store;
+        };
+
+        // Reconstruct the stores
+        const store = reconstructStore(positiveValues);
+        const negativeStore = reconstructStore(negativeValues);
+
+        return new BaseDDSketch({ mapping, store, negativeStore, zeroCount });
+    }
 }
 
 interface SketchConfig {

--- a/test/ddsketch.test.ts
+++ b/test/ddsketch.test.ts
@@ -123,6 +123,100 @@ function test(DDSketch: any) {
         evaluateSketchAccuracy(decodedProto, data);
     });
 
+    it('can be serialized to and from JSON', () => {
+        const data = generateIncreasing(100);
+        const sketch = new DDSketch({ relativeAccuracy });
+
+        for (const value of data) {
+            sketch.accept(value);
+        }
+
+        evaluateSketchAccuracy(sketch, data);
+
+        const json = sketch.toJSON();
+        const decodedJSON = DDSketch.fromJSON(json);
+
+        evaluateSketchAccuracy(decodedJSON, data);
+    });
+
+    it('produces the same quantiles after JSON round-trip as original', () => {
+        // Test with various datasets to ensure JSON serialization is lossless
+        const testCases = [
+            { name: 'random values', data: generateRandom(500) },
+            {
+                name: 'positive and negative',
+                data: generatePositiveAndNegative(500)
+            },
+            { name: 'constant values', data: generateConstant(100) },
+            { name: 'random integers', data: generateRandomIntegers(300) }
+        ];
+
+        for (const testCase of testCases) {
+            const sketch = new DDSketch({ relativeAccuracy });
+
+            for (const value of testCase.data) {
+                sketch.accept(value);
+            }
+
+            const json = sketch.toJSON();
+            const restored = DDSketch.fromJSON(json);
+
+            // Verify count matches
+            expect(restored.count).toEqual(sketch.count);
+
+            // Verify all quantiles match (within floating-point precision)
+            for (const quantile of testQuantiles) {
+                const original = sketch.getValueAtQuantile(quantile);
+                const restoredValue = restored.getValueAtQuantile(quantile);
+
+                // Quantiles should match within floating-point precision
+                // Allow small differences due to floating-point arithmetic
+                // during reconstruction - much smaller than the sketch's
+                // relative accuracy guarantee
+                if (!Number.isNaN(original)) {
+                    const relativeError =
+                        Math.abs(original - restoredValue) / Math.abs(original);
+                    expect(relativeError).toBeLessThan(1e-6);
+                } else {
+                    expect(restoredValue).toEqual(original);
+                }
+            }
+
+            // Also verify the restored sketch is accurate against the original data
+            evaluateSketchAccuracy(restored, testCase.data);
+        }
+    });
+
+    it('produces compact JSON representation', () => {
+        const sketch = new DDSketch({ relativeAccuracy });
+
+        // Add sparse data
+        sketch.accept(100);
+        sketch.accept(500);
+        sketch.accept(1000);
+
+        const json = sketch.toJSON();
+
+        // JSON should be an array of length 5
+        expect(Array.isArray(json)).toBe(true);
+        expect(json.length).toEqual(5);
+
+        // Verify structure: [gamma, indexOffset, positiveValues, negativeValues, zeroCount]
+        expect(typeof json[0]).toBe('number'); // gamma
+        expect(typeof json[1]).toBe('number'); // indexOffset
+        expect(Array.isArray(json[2])).toBe(true); // positiveValues
+        expect(Array.isArray(json[3])).toBe(true); // negativeValues
+        expect(typeof json[4]).toBe('number'); // zeroCount
+
+        // Positive values should be sparse: [offset, [idx, count], ...]
+        const positiveValues = json[2] as unknown[];
+        expect(positiveValues.length).toBeGreaterThan(0);
+        expect(typeof positiveValues[0]).toBe('number'); // offset
+
+        // Should only have non-zero bins (3 values = 3 non-zero bins)
+        expect(positiveValues.length).toBe(4); // offset + 3 sparse entries
+    });
+
     describe('datasets', () => {
         for (const dataset of datasets) {
             it(`is accurate for dataset '${dataset.name}'`, () => {


### PR DESCRIPTION
This PR adds two new functions to the DDSketch class which converts down into a very compact JSON format for de/serialization. I've found in testing they end up being about 1kb of JSON data. The codes a bit verbose, but I figured more error checking is better.

I added some tests to verify that the process is not lossy

As I'm in no rush to get it merged, I've released it on npm under my namespace too - www.npmjs.com/package/@orta/sketches-js