### PR TITLE
[SINT-4682] Update publish workflow to use NPM trusted publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,13 +5,15 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v4
         with:
-          node-version: '12.x'
+          node-version: '24'
+          registry-url: 'https://registry.npmjs.org'
       - run: yarn
       - run: yarn pack
-      - run: yarn publish
-        env:
-          NPM_AUTH_TOKEN: ${{ secrets.YARN_NPM_AUTH_TOKEN }}
+      - run: npm publish


### PR DESCRIPTION
## Overview

Updates the `publish.yml` workflow to use NPM trusted publishing. Requires:
- Giving the `id-token: write` permission to the workflow,
- Updating the node version to be recent enough to use trusted publishing,
- Using `npm` instead of `yarn` for the publishing.

## Motivation

Adhere to NPM releasing best practices.